### PR TITLE
Ability to toggle Grove visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Workspace:
 (keymap (global)
   (normal
     (space
-      (e ":grove-focus!"))))
+      (e ":grove-focus!")
+      (E ":grove-toggle-pinned!"))))
 ```
 
-This binds `Space e` to Grove. Merge the binding into your existing keymap or
-choose another chord if `Space e` is already taken.
+This binds `Space e` to Grove and `Space E` to toggle Grove visibility. Merge the binding into your existing keymap or choose another chord if `Space e`/`Space E` is already taken.
 
 Do not use `hx .` with either mode. Helix treats a positional directory as a
 request to open its native file picker before Steel components mount.

--- a/grove.scm
+++ b/grove.scm
@@ -1,7 +1,7 @@
 (require "helix/components.scm")
 (require (prefix-in helix. "src/adapters/helix.scm"))
 
-(provide grove-theme grove-start! grove-focus!)
+(provide grove-theme grove-start! grove-focus! grove-toggle-pinned!)
 
 (struct grove-theme-value (sources))
 
@@ -97,3 +97,8 @@
 ;;Focus Grove.
 (define (grove-focus!)
   (helix.focus!))
+
+;;@doc
+;;Toggle Grove's show state between pinned (always visible) and unpinned (visible only when focused).
+(define (grove-toggle-pinned!)
+  (helix.toggle-pinned!))

--- a/src/adapters/helix.scm
+++ b/src/adapters/helix.scm
@@ -14,7 +14,7 @@
 (require (prefix-in theme. "helix/theme.scm"))
 (require (prefix-in component. "helix/component.scm"))
 
-(provide start! focus!)
+(provide start! focus! toggle-pinned!)
 
 (define REFRESH-INTERVAL-MS 2000)
 
@@ -22,6 +22,7 @@
 (define *latest-frame* #f)
 (define *focus-next-frame?* #f)
 (define *started?* #f)
+(define *pinned?* #f)
 (define *theme-sources* '())
 
 (struct rendered-frame (root layout))
@@ -102,7 +103,12 @@
       (dispatch! model.focus-frame-observed snapshot geometry))
     (dispatch! model.geometry-observed geometry))
   (define model-at-render *model*)
-  (define current-layout (model.resolved-layout model-at-render))
+  ; (define current-layout (model.resolved-layout model-at-render))
+  (define current-layout
+    (and
+      (or *pinned?*
+          (model.focused? model-at-render))
+      (model.resolved-layout model-at-render)))
   (if current-layout
     (begin
       (component.apply-clip! (layout.width current-layout))
@@ -156,4 +162,9 @@
   (when *model*
     (set! *focus-next-frame?* #t)
     (helix.redraw))
+  void)
+
+(define (toggle-pinned!)
+  (set! *pinned?* (not *pinned?*))
+  (helix.redraw)
   void)

--- a/src/adapters/helix.scm
+++ b/src/adapters/helix.scm
@@ -103,7 +103,6 @@
       (dispatch! model.focus-frame-observed snapshot geometry))
     (dispatch! model.geometry-observed geometry))
   (define model-at-render *model*)
-  ; (define current-layout (model.resolved-layout model-at-render))
   (define current-layout
     (and
       (or *pinned?*

--- a/src/adapters/helix.scm
+++ b/src/adapters/helix.scm
@@ -14,7 +14,7 @@
 (require (prefix-in theme. "helix/theme.scm"))
 (require (prefix-in component. "helix/component.scm"))
 
-(provide start! focus!)
+(provide start! focus! toggle-pinned!)
 
 (define REFRESH-INTERVAL-MS 2000)
 
@@ -22,6 +22,7 @@
 (define *latest-frame* #f)
 (define *focus-next-frame?* #f)
 (define *started?* #f)
+(define *pinned?* #t)
 (define *theme-sources* '())
 
 (struct rendered-frame (root layout))
@@ -102,7 +103,12 @@
       (dispatch! model.focus-frame-observed snapshot geometry))
     (dispatch! model.geometry-observed geometry))
   (define model-at-render *model*)
-  (define current-layout (model.resolved-layout model-at-render))
+  ; (define current-layout (model.resolved-layout model-at-render))
+  (define current-layout
+    (and
+      (or *pinned?*
+          (model.focused? model-at-render))
+      (model.resolved-layout model-at-render)))
   (if current-layout
     (begin
       (component.apply-clip! (layout.width current-layout))
@@ -156,4 +162,9 @@
   (when *model*
     (set! *focus-next-frame?* #t)
     (helix.redraw))
+  void)
+
+(define (toggle-pinned!)
+  (set! *pinned?* (not *pinned?*))
+  (helix.redraw)
   void)

--- a/src/adapters/helix/component.scm
+++ b/src/adapters/helix/component.scm
@@ -17,8 +17,7 @@
       (set-editor-clip-left! width)
       (set-editor-clip-right! width))
     (set! *clip-width* width)
-    ; Redraw in case the panel is not pinned.
-    ; Otherwise input is required to fix the editor alignment.
+    ; This redraw fixes the editor's alignment in case the grove file tree is not pinned.
     (helix.redraw)))
 
 (define (install! side render! handle-event!)

--- a/src/adapters/helix/component.scm
+++ b/src/adapters/helix/component.scm
@@ -2,6 +2,7 @@
 (require "helix/ext.scm")
 (require "helix/misc.scm")
 (require "helix/editor.scm")
+(require (prefix-in helix. "helix/commands.scm"))
 (require (prefix-in layout. "../../domain/layout.scm"))
 
 (provide install! apply-clip!)
@@ -15,7 +16,10 @@
     (if (equal? *clip-side* 'left)
       (set-editor-clip-left! width)
       (set-editor-clip-right! width))
-    (set! *clip-width* width)))
+    (set! *clip-width* width)
+    ; Redraw in case the panel is not pinned.
+    ; Otherwise input is required to fix the editor alignment.
+    (helix.redraw)))
 
 (define (install! side render! handle-event!)
   (set! *clip-side* side)


### PR DESCRIPTION
Hello, nice file tree plugin.

I wanted to be able to toggle the visibility between "always visible" and "only visible when focused", so I added it there as the ":grove-toggle-pinned!" command.

